### PR TITLE
Retailer client tests

### DIFF
--- a/app/Clients/Amazon.php
+++ b/app/Clients/Amazon.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace App\Clients;
+
+
+use App\Stock;
+use Illuminate\Support\Facades\Http;
+
+class Amazon implements Client
+{
+
+    /**
+     * @param Stock $stock
+     * @return StockCheckResponse
+     */
+    public function checkAvailability(Stock $stock): StockCheckResponse
+    {
+        $results = Http::get('https://foo.test')->json();
+
+        return new StockCheckResponse(
+            $results['available'],
+            $results['price']
+        );
+    }
+}

--- a/app/Clients/Client.php
+++ b/app/Clients/Client.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace App\Clients;
+
+
+use App\Stock;
+
+interface Client
+{
+    public function checkAvailability(Stock $stock): StockCheckResponse;
+}

--- a/app/Clients/ClientException.php
+++ b/app/Clients/ClientException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace App\Clients;
+
+
+class ClientException extends \Exception
+{
+
+}

--- a/app/Clients/ClientFactory.php
+++ b/app/Clients/ClientFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace App\Clients;
+
+
+use App\Retailer;
+use Illuminate\Support\Str;
+
+class ClientFactory
+{
+    public function make(Retailer $retailer): Client
+    {
+        $class = "App\\Clients\\" . Str::studly($retailer->name);
+
+        if(!class_exists($class)) {
+            throw new ClientException('Client not found for ' . $retailer->name);
+        }
+
+        return new $class;
+    }
+}

--- a/app/Clients/Ebay.php
+++ b/app/Clients/Ebay.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace App\Clients;
+
+
+use App\Stock;
+
+class Ebay implements Client
+{
+
+    public function checkAvailability(Stock $stock): StockCheckResponse
+    {
+        // TODO: Implement checkAvailability() method.
+    }
+}

--- a/app/Clients/StockCheckResponse.php
+++ b/app/Clients/StockCheckResponse.php
@@ -14,7 +14,7 @@ class StockCheckResponse
      * @param $available
      * @param $price
      */
-    public function __construct($available, $price)
+    public function __construct(bool $available, int $price)
     {
         $this->available = $available;
         $this->price = $price;

--- a/app/Clients/StockCheckResponse.php
+++ b/app/Clients/StockCheckResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace App\Clients;
+
+
+class StockCheckResponse
+{
+    public $available;
+    public $price;
+
+    /**
+     * StockCheckResponse constructor.
+     * @param $available
+     * @param $price
+     */
+    public function __construct($available, $price)
+    {
+        $this->available = $available;
+        $this->price = $price;
+    }
+}

--- a/app/Retailer.php
+++ b/app/Retailer.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use Facades\App\Clients\ClientFactory;
+
 class Retailer extends Model
 {
     protected $fillable = ['name'];
@@ -15,5 +17,10 @@ class Retailer extends Model
     public function stock()
     {
         return $this->hasMany(Stock::class);
+    }
+
+    public function client()
+    {
+        return ClientFactory::make($this);
     }
 }

--- a/app/Stock.php
+++ b/app/Stock.php
@@ -2,8 +2,9 @@
 
 namespace App;
 
+
+use Facades\App\Clients\ClientFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Http;
 
 class Stock extends Model
 {
@@ -21,17 +22,15 @@ class Stock extends Model
 
     public function track()
     {
-        if ($this->retailer->name === 'Amazon') {
-            // Hit an API endpoint for the associated retailer
-            // Fetch the up to date details for the item
-            $results = Http::get('https://foo.test')->json();
+        $stockStatus = $this->retailer
+            ->client()
+            ->checkAvailability($this);
 
-            // Then fresh the current stock record
-            $this->update([
-                'in_stock' => $results['available'],
-                'price' => $results['price']
-            ]);
-        }
+        // Then fresh the current stock record
+        $this->update([
+            'in_stock' => $stockStatus->available,
+            'price' => $stockStatus->price
+        ]);
     }
 
     public function retailer()

--- a/tests/Feature/TrackCommandTest.php
+++ b/tests/Feature/TrackCommandTest.php
@@ -2,12 +2,10 @@
 
 namespace Tests\Feature;
 
+use Facades\App\Clients\ClientFactory;
+use App\Clients\StockCheckResponse;
 use App\Product;
-use App\Retailer;
-use App\Stock;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class TrackCommandTest extends TestCase
@@ -25,18 +23,17 @@ class TrackCommandTest extends TestCase
         // A product with a stock
         $this->seed(\RetailerWithProductSeeder::class);
         $this->assertFalse(Product::first()->inStock());
+
+        ClientFactory::shouldReceive('make->checkAvailability')
+            ->andReturn(new StockCheckResponse($available = true, $price = 5000));
+
         // When
         // The php artisan track command is triggered, assuming the stock is now available
-        Http::fake(fn() => [
-                'available' => 'true',
-                'price' => 25000
-        ]);
-
         $this->artisan('track')
             ->expectsOutput(('Product Stock Tracking command run successfully!'));
 
         // Then
         // The stock details for the product should be refreshed
-        $this->assertFalse(Product::first()->inStock());
+        $this->assertTrue(Product::first()->inStock());
     }
 }

--- a/tests/Unit/StockTest.php
+++ b/tests/Unit/StockTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit;
 
 
-use App\Clients\Client;
 use App\Clients\ClientException;
 use Facades\App\Clients\ClientFactory;
 use App\Clients\StockCheckResponse;
@@ -33,9 +32,9 @@ class StockTest extends TestCase
         $this->seed(\RetailerWithProductSeeder::class);
         // Uses client factory to determine the appropriate client
         // And runs checkAvailablity
-        ClientFactory::shouldReceive('make')->andReturn(new FakeClient);
-
-
+        ClientFactory::shouldReceive('make->checkAvailability')->andReturn(
+            new StockCheckResponse($available = true, $price = 5000)
+        );
 
         $stock = tap(Stock::first())->track();
 
@@ -44,10 +43,3 @@ class StockTest extends TestCase
     }
 }
 
-class FakeClient implements Client
-{
-    public function checkAvailability(Stock $stock): StockCheckResponse
-    {
-        return new StockCheckResponse($available = true, $price = 5000);
-    }
-}

--- a/tests/Unit/StockTest.php
+++ b/tests/Unit/StockTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+
+use App\Clients\ClientException;
+use App\Retailer;
+use App\Stock;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StockTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test **/
+    public function it_throws_an_exception_if_a_client_is_not_found_when_tracking()
+    {
+        $this->seed(\RetailerWithProductSeeder::class);
+        Retailer::first()->update(['name' => 'Foo Retailer']);
+
+        $this->expectException(ClientException::class);
+
+        Stock::first()->track();
+    }
+}


### PR DESCRIPTION
Extracted each Retailer Client into a new Client class, normalising the shared functionality using an interface and creating a ClientFactory which is passed Retailer to make an instance if client is available for the retailer otherwise throw a ClientException.

 Added test case for when the local stock status is updated after being Tracked using a mock FakeClient class returning a StockCheckResponse.

 Instead of using the FakeClient class this has been refactored to use a shouldReceive facade as well as andReturn methods in order to make the tests more readable and fake the StockCheckResponse.


